### PR TITLE
chore(config): align build/runtime defaults and Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:17
 RUN mkdir -p /app/
 WORKDIR /app/
-#COPY /target/pathfinders-0.1.jar /app/pathfinders.jar
-COPY pathfinders-0.1.jar /app/pathfinders.jar
+COPY target/pathfinders-0.1.jar /app/pathfinders.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app/pathfinders.jar"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pathfinders - это веб-приложение для управления к�
 
 ## 🚀 Технологический стек
 
-- **Backend**: Java 17, Spring Boot 2.x
+- **Backend**: Java 17, Spring Boot 3.1.x
 - **Database**: PostgreSQL 14+
 - **Build Tool**: Maven
 - **Containerization**: Docker, Docker Compose
@@ -39,7 +39,7 @@ docker-compose -f docker-compose-psgr.yml up -d
 docker-compose -f docker-compose-app.yml up --build
 ```
 
-4. Откройте браузер и перейдите по адресу: `http://localhost:8080`
+4. Откройте браузер и перейдите по адресу: `http://localhost:9090`
 
 ### Вариант 2: Локальная разработка
 
@@ -60,7 +60,7 @@ java -jar target/pathfinders-*.jar
 
 ## 👤 Доступ по умолчанию
 
-- **URL**: http://localhost:8080/
+- **URL**: http://localhost:9090/
 - **Логин**: `dir`
 - **Пароль**: `dir`
 - **Роль**: Директор клуба
@@ -119,6 +119,14 @@ SPRING_DATASOURCE_PASSWORD=postgres
 
 # Порт приложения
 SERVER_PORT=8080
+
+# Управление схемой БД (dev/test)
+SPRING_JPA_HIBERNATE_DDL_AUTO=update
+
+# Детализация ошибок (dev)
+SERVER_ERROR_INCLUDE_MESSAGE=always
+SERVER_ERROR_INCLUDE_BINDING_ERRORS=always
+SERVER_ERROR_INCLUDE_STACKTRACE=on_param
 ```
 
 ### application.yml

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -3,7 +3,7 @@ services:
   app:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.optimized
     container_name: app
     ports:
       - "9090:8080"
@@ -16,5 +16,4 @@ services:
 
 networks:
   my-network:
-    external: true
-
+    name: pathfinders-network

--- a/docker-compose-psgr.yml
+++ b/docker-compose-psgr.yml
@@ -17,8 +17,8 @@ services:
 
 networks:
   my-network:
-    external: true
+    name: pathfinders-network
 
 volumes:
   my_volume:
-    external: true
+    name: pathfinders-data

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <checkstyle-plugin.version>3.2.2</checkstyle-plugin.version>
         <checkstyle.version>10.11.0</checkstyle.version>
+        <liquibase.version>4.24.0</liquibase.version>
         <checkstyle.config.url>
             https://raw.githubusercontent.com/OtusTeam/Spring/master/checkstyle.xml
         </checkstyle.config.url>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
   
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
     show-sql: ${SPRING_JPA_SHOW_SQL:false}
     properties:
       hibernate:
@@ -25,9 +25,9 @@ spring:
 server:
   port: ${SERVER_PORT:8080}
   error:
-    include-message: always
-    include-binding-errors: always
-    include-stacktrace: on_param
+    include-message: ${SERVER_ERROR_INCLUDE_MESSAGE:never}
+    include-binding-errors: ${SERVER_ERROR_INCLUDE_BINDING_ERRORS:never}
+    include-stacktrace: ${SERVER_ERROR_INCLUDE_STACKTRACE:never}
     include-exception: false
 
 # Actuator для health checks


### PR DESCRIPTION
### Motivation
- Keep the build reproducible by declaring the Liquibase plugin version in `pom.xml`.
- Harden runtime defaults to avoid accidental schema changes and leaking internal error details in production.
- Align container build, ports and networking configuration across Dockerfiles, Compose files and documentation.
- Ensure the `Dockerfile` copies the built artifact from the Maven `target` directory.

### Description
- Added `<liquibase.version>4.24.0</liquibase.version>` to `pom.xml`.
- Changed `src/main/resources/application.yml` to use env-driven defaults for `spring.jpa.hibernate.ddl-auto` (default `validate`) and server error detail flags (`SERVER_ERROR_INCLUDE_*`).
- Updated `Dockerfile` to `COPY target/pathfinders-0.1.jar`, switched app compose to use `Dockerfile.optimized`, and renamed Compose network/volume entries to `pathfinders-network` and `pathfinders-data` in `docker-compose-app.yml` and `docker-compose-psgr.yml`.
- Updated `README.md` to reflect `Spring Boot 3.1.x`, the new default port `9090`, and added example env vars for `SPRING_JPA_HIBERNATE_DDL_AUTO` and server error settings.

### Testing
- No automated tests were executed for this change because it only modifies configuration and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514cb28164832398d98c02f48fabe9)