### PR TITLE
Add GitHub Actions CI workflow for Maven tests and Checkstyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Run tests
+        run: mvn -B clean test
+
+      - name: Checkstyle
+        run: mvn -B checkstyle:check
+
+      - name: Package jar
+        run: mvn -B -DskipTests package
+
+      - name: Upload jar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: target/*.jar
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Add continuous integration to run project tests and static checks on pushes and pull requests.
- Enforce Checkstyle rules already declared in the `pom.xml` during CI runs.
- Reduce build time by caching the Maven repository between runs.
- Enable packaging and uploading of the built jar for downstream deployment or distribution.

### Description
- Create `.github/workflows/ci.yml` with a `build` job that triggers on `push` and `pull_request` events.
- Use `actions/setup-java@v4` with `java-version: 17` and `cache: maven` to set up JDK and cache dependencies.
- Run `mvn -B clean test` and `mvn -B checkstyle:check`, then package with `mvn -B -DskipTests package`.
- Upload produced jar(s) from `target/*.jar` using `actions/upload-artifact@v4` as `app-jar`.

### Testing
- No automated tests were executed locally because the CI workflow is intended to run on GitHub Actions.
- The workflow will execute `mvn -B clean test` and `mvn -B checkstyle:check` on each push and PR.
- The package step will run `mvn -B -DskipTests package` and upload the resulting artifacts as `app-jar`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695152a3484483238098649c04a3877d)